### PR TITLE
Change packaging to not fail on extraneous files

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -106,7 +106,8 @@ This document describes CLI design and behavior (data flow, config, and contract
   - Publishes the bundle to IPFS by default (uses `http://127.0.0.1:5001`).
   - `--no-ipfs` skips publish and returns a deterministic hash of the manifest.
   - `--ipfs-api` overrides the IPFS API URL.
-  - Validates top-level structure: `src/`, `assets/`, `abis/`, `addresses.json`, `index.html`, `package.json`.
+  - Requires top-level bundle inputs: `src/`, `assets/`, `abis/`, `addresses.json`, `index.html`, `package.json`.
+  - Ignores extra files/directories outside constrained bundle paths during packaging.
   - Enforces dependency allowlist + exact versions.
   - Rejects forbidden patterns (HTTP, fetch/XHR/WebSocket, dynamic HTTP imports).
   - Generates a `manifest.json` with file hashes and metadata.


### PR DESCRIPTION
## Summary
This change makes `package` tolerant of extra files in a dapp repo while keeping strict validation for bundle inputs.

## New functionality
- Packaging now **requires** the core inputs (`src/`, `assets/`, `abis/`, `addresses.json`, `index.html`, `package.json`) but no longer fails when unrelated top-level files/directories are present.
- Validation is scoped to bundle content only:
  - `src/` files still enforce allowed extensions and forbidden-content checks.
  - `assets/` and `abis/` keep extension/JSON validation.
  - `addresses.json` and `index.html` remain explicitly validated.
- Hidden files are skipped during bundle collection.
- Output directory cleanup is now explicit before writing, preventing stale files from previous packaging runs.

## Why this matters
Projects can keep extra workspace files (docs, tooling, scripts, etc.) without breaking packaging, while security/consistency checks for shipped bundle content remain intact.
