### PR TITLE
Use vibefi.json for pre-bundle vapp properties

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -116,11 +116,12 @@ This document describes CLI design and behavior (data flow, config, and contract
   - Publishes the bundle to IPFS by default (uses `http://127.0.0.1:5001`).
   - `--no-ipfs` skips publish and returns a deterministic hash of the manifest.
   - `--ipfs-api` overrides the IPFS API URL.
-  - Requires top-level bundle inputs: `src/`, `assets/`, `abis/`, `addresses.json`, `index.html`, `package.json`.
+  - Requires top-level bundle inputs: `src/`, `assets/`, `abis/`, `vibefi.json`, `index.html`, `package.json`.
   - Ignores extra files/directories outside constrained bundle paths during packaging.
   - Enforces dependency allowlist + exact versions.
   - Rejects forbidden patterns (HTTP, fetch/XHR/WebSocket, dynamic HTTP imports).
-  - Generates a `manifest.json` with file hashes and metadata.
+  - Reads source properties from `vibefi.json` (`addresses`, optional `capabilities`).
+  - Generates a post-bundle `manifest.json` with file hashes and metadata.
   - Emits a bundle directory that can be proposed via `dapp:propose`.
 
 ## Contract Interactions

--- a/tests/package.manifest.test.ts
+++ b/tests/package.manifest.test.ts
@@ -15,16 +15,19 @@ afterEach(() => {
   }
 });
 
-function createManifestDir(manifest: unknown): string {
+function createManifestDir(vibefi: unknown): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vibefi-cli-manifest-"));
   tempDirs.push(dir);
-  fs.writeFileSync(path.join(dir, "manifest.json"), JSON.stringify(manifest, null, 2));
+  fs.writeFileSync(path.join(dir, "vibefi.json"), JSON.stringify(vibefi, null, 2));
   return dir;
 }
 
 describe("readSourceManifest capability validation", () => {
   test("rejects non-positive maxBytes", () => {
     const dir = createManifestDir({
+      addresses: {
+        pool: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+      },
       capabilities: {
         ipfs: {
           allow: [
@@ -43,6 +46,9 @@ describe("readSourceManifest capability validation", () => {
 
   test("rejects invalid read kind in as", () => {
     const dir = createManifestDir({
+      addresses: {
+        pool: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+      },
       capabilities: {
         ipfs: {
           allow: [
@@ -60,6 +66,9 @@ describe("readSourceManifest capability validation", () => {
 
   test("rejects empty paths array", () => {
     const dir = createManifestDir({
+      addresses: {
+        pool: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+      },
       capabilities: {
         ipfs: {
           allow: [
@@ -77,6 +86,9 @@ describe("readSourceManifest capability validation", () => {
 
   test("accepts valid capabilities payload", () => {
     const dir = createManifestDir({
+      addresses: {
+        pool: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2",
+      },
       capabilities: {
         ipfs: {
           allow: [
@@ -94,5 +106,17 @@ describe("readSourceManifest capability validation", () => {
     const manifest = readSourceManifest(dir);
     expect(manifest.capabilities?.ipfs?.allow.length).toBe(1);
     expect(manifest.capabilities?.ipfs?.allow[0]?.as).toEqual(["snippet", "text"]);
+  });
+
+  test("requires addresses in vibefi.json", () => {
+    const dir = createManifestDir({
+      capabilities: {
+        ipfs: {
+          allow: [],
+        },
+      },
+    });
+
+    expect(() => readSourceManifest(dir)).toThrow(/addresses is required/i);
   });
 });


### PR DESCRIPTION
## Summary
- replace pre-bundle inputs manifest.json + addresses.json with vibefi.json
- validate vibefi.json.addresses and optional vibefi.json.capabilities
- keep generated post-bundle manifest.json behavior unchanged
- update package tests and CLI spec text

## Validation
- bun run test:unit
- bun run typecheck
