### PR TITLE
Support static-html packaging with strict file allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ prints the folder CID for `dapp:propose`.
 
 Supported layouts:
 - constrained React/Vite layout: `src/`, `assets/`, `abis/`, `vibefi.json`, `index.html`, `package.json`
-- static-html layout: `vibefi.json`, `index.html`, and only approved static file types (`.html`, `.js`, `.css`, images, fonts, `.json`, `.wasm`, etc.)
+- static-html layout: `vibefi.json`, `index.html`, and only `.html`, `.js`, `.json` files
 
 ```bash
 bun run src/index.ts package \

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ The `package` command validates a local dapp bundle and produces a deterministic
 manifest + bundle directory. By default it publishes to a local IPFS node and
 prints the folder CID for `dapp:propose`.
 
+Supported layouts:
+- constrained React/Vite layout: `src/`, `assets/`, `abis/`, `vibefi.json`, `index.html`, `package.json`
+- static-html layout: `vibefi.json`, `index.html`, and only approved static file types (`.html`, `.js`, `.css`, images, fonts, `.json`, `.wasm`, etc.)
+
 ```bash
 bun run src/index.ts package \
   --path ./my-dapp \

--- a/SPEC.md
+++ b/SPEC.md
@@ -112,14 +112,16 @@ This document describes CLI design and behavior (data flow, config, and contract
 
 - `vibefi package`
   - Use `--dapp-version` (not `--version`) to avoid conflicting with CLI version flag.
-  - Validates a local React dapp bundle and outputs a deterministic `rootCid`.
+  - Validates a local dapp bundle and outputs a deterministic `rootCid`.
   - Publishes the bundle to IPFS by default (uses `http://127.0.0.1:5001`).
   - `--no-ipfs` skips publish and returns a deterministic hash of the manifest.
   - `--ipfs-api` overrides the IPFS API URL.
-  - Requires top-level bundle inputs: `src/`, `assets/`, `abis/`, `vibefi.json`, `index.html`, `package.json`.
-  - Ignores extra files/directories outside constrained bundle paths during packaging.
-  - Enforces dependency allowlist + exact versions.
-  - Rejects forbidden patterns (HTTP, fetch/XHR/WebSocket, dynamic HTTP imports).
+  - Supports two layouts:
+    - constrained: `src/`, `assets/`, `abis/`, `vibefi.json`, `index.html`, `package.json`.
+    - static-html: `vibefi.json`, `index.html`, plus approved static file types only.
+  - Constrained layout enforces dependency allowlist + exact versions.
+  - Constrained layout rejects forbidden patterns (HTTP, fetch/XHR/WebSocket, dynamic HTTP imports).
+  - Static-html layout bundles non-dotfiles recursively (excluding build/cache dirs like `node_modules`, `dist`, `.vibefi`) and rejects disallowed extensions.
   - Reads source properties from `vibefi.json` (`addresses`, optional `capabilities`).
   - Generates a post-bundle `manifest.json` with file hashes and metadata.
   - Emits a bundle directory that can be proposed via `dapp:propose`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -118,10 +118,10 @@ This document describes CLI design and behavior (data flow, config, and contract
   - `--ipfs-api` overrides the IPFS API URL.
   - Supports two layouts:
     - constrained: `src/`, `assets/`, `abis/`, `vibefi.json`, `index.html`, `package.json`.
-    - static-html: `vibefi.json`, `index.html`, plus approved static file types only.
+    - static-html: `vibefi.json`, `index.html`, plus only `.html`, `.js`, and `.json` files.
   - Constrained layout enforces dependency allowlist + exact versions.
   - Constrained layout rejects forbidden patterns (HTTP, fetch/XHR/WebSocket, dynamic HTTP imports).
-  - Static-html layout bundles non-dotfiles recursively (excluding build/cache dirs like `node_modules`, `dist`, `.vibefi`) and rejects disallowed extensions.
+  - Static-html layout bundles non-dotfiles recursively (excluding build/cache dirs like `node_modules`, `dist`, `.vibefi`) and rejects all extensions except `.html`, `.js`, `.json`.
   - Reads source properties from `vibefi.json` (`addresses`, optional `capabilities`).
   - Generates a post-bundle `manifest.json` with file hashes and metadata.
   - Emits a bundle directory that can be proposed via `dapp:propose`.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "bun run src/index.ts",
     "refresh-abis": "bun run scripts/refresh-abis.ts",
-    "test:unit": "bun test tests/package.manifest.test.ts",
+    "test:unit": "bun test tests/*.test.ts",
     "test:e2e": "echo \"Moved to vibefi-e2e repo\" && exit 1",
     "test:smoke": "bun run scripts/smoke-test.ts",
     "typecheck": "bun run tsc -p tsconfig.json --noEmit"

--- a/src/package.ts
+++ b/src/package.ts
@@ -35,30 +35,8 @@ type BundleLayout = "constrained" | "static-html";
 
 const STATIC_HTML_ALLOWED_EXTENSIONS = new Set([
   ".html",
-  ".htm",
   ".js",
-  ".mjs",
-  ".cjs",
-  ".css",
-  ".json",
-  ".map",
-  ".svg",
-  ".png",
-  ".jpg",
-  ".jpeg",
-  ".webp",
-  ".gif",
-  ".ico",
-  ".bmp",
-  ".avif",
-  ".woff",
-  ".woff2",
-  ".ttf",
-  ".otf",
-  ".eot",
-  ".wasm",
-  ".txt",
-  ".xml"
+  ".json"
 ]);
 
 type ManifestFile = {

--- a/tests/package.layout.test.ts
+++ b/tests/package.layout.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { packageDapp } from "../src/package";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+function createTempDir(prefix: string) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeJson(filePath: string, value: unknown) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeText(filePath: string, value: string) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, value);
+}
+
+describe("packageDapp layout support", () => {
+  test("packages constrained layout", async () => {
+    const dir = createTempDir("vibefi-cli-constrained-");
+    fs.mkdirSync(path.join(dir, "src"));
+    fs.mkdirSync(path.join(dir, "assets"));
+    fs.mkdirSync(path.join(dir, "abis"));
+    writeText(path.join(dir, "src", "main.ts"), "export const ok = 1;\n");
+    fs.writeFileSync(path.join(dir, "assets", "logo.webp"), "webp");
+    writeJson(path.join(dir, "abis", "Foo.json"), []);
+    writeText(path.join(dir, "index.html"), "<!doctype html><title>ok</title>\n");
+    writeJson(path.join(dir, "package.json"), { name: "constrained", private: true, version: "0.0.1", type: "module" });
+    writeJson(path.join(dir, "vibefi.json"), {
+      addresses: {
+        "31337": {
+          dappRegistry: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+        }
+      }
+    });
+
+    const result = await packageDapp({
+      path: dir,
+      name: "Constrained",
+      version: "0.0.1",
+      description: "test",
+      ipfs: false
+    });
+
+    expect((result.manifest as { layout?: string }).layout).toBe("constrained");
+    expect(fs.existsSync(path.join(result.outDir, "src", "main.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(result.outDir, "assets", "logo.webp"))).toBe(true);
+    expect(fs.existsSync(path.join(result.outDir, "abis", "Foo.json"))).toBe(true);
+  });
+
+  test("packages static-html layout without package.json/src/assets/abis", async () => {
+    const dir = createTempDir("vibefi-cli-static-");
+    writeText(path.join(dir, "index.html"), "<!doctype html><script src=\"https://cdn.example/app.js\"></script>\n");
+    writeText(path.join(dir, "app.js"), "console.log('ok');\n");
+    writeText(path.join(dir, "domains", "index.html"), "<!doctype html><title>subpage</title>\n");
+    writeJson(path.join(dir, "vibefi.json"), {
+      addresses: {
+        "31337": {
+          dappRegistry: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+        }
+      }
+    });
+    writeText(path.join(dir, "manifest.json"), "{\"stale\":true}\n");
+    writeText(path.join(dir, "node_modules", "pkg", "index.js"), "ignored");
+
+    const result = await packageDapp({
+      path: dir,
+      name: "Static",
+      version: "0.0.1",
+      description: "test",
+      ipfs: false
+    });
+
+    expect((result.manifest as { layout?: string }).layout).toBe("static-html");
+    expect(fs.existsSync(path.join(result.outDir, "index.html"))).toBe(true);
+    expect(fs.existsSync(path.join(result.outDir, "app.js"))).toBe(true);
+    expect(fs.existsSync(path.join(result.outDir, "domains", "index.html"))).toBe(true);
+    expect(fs.existsSync(path.join(result.outDir, "manifest.json"))).toBe(true);
+    expect(fs.existsSync(path.join(result.outDir, "node_modules"))).toBe(false);
+  });
+
+  test("still validates constrained dependency allowlist", async () => {
+    const dir = createTempDir("vibefi-cli-constrained-bad-deps-");
+    fs.mkdirSync(path.join(dir, "src"));
+    fs.mkdirSync(path.join(dir, "assets"));
+    fs.mkdirSync(path.join(dir, "abis"));
+    writeText(path.join(dir, "src", "main.ts"), "export const ok = 1;\n");
+    fs.writeFileSync(path.join(dir, "assets", "logo.webp"), "webp");
+    writeJson(path.join(dir, "abis", "Foo.json"), []);
+    writeText(path.join(dir, "index.html"), "<!doctype html><title>ok</title>\n");
+    writeJson(path.join(dir, "package.json"), {
+      name: "constrained",
+      private: true,
+      version: "0.0.1",
+      type: "module",
+      dependencies: {
+        lodash: "4.17.21"
+      }
+    });
+    writeJson(path.join(dir, "vibefi.json"), {
+      addresses: {
+        "31337": {
+          dappRegistry: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+        }
+      }
+    });
+
+    await expect(
+      packageDapp({
+        path: dir,
+        name: "Constrained",
+        version: "0.0.1",
+        description: "test",
+        ipfs: false
+      })
+    ).rejects.toThrow(/Dependency not allowed/i);
+  });
+
+  test("rejects disallowed file extensions in static-html layout", async () => {
+    const dir = createTempDir("vibefi-cli-static-bad-ext-");
+    writeText(path.join(dir, "index.html"), "<!doctype html><title>static</title>\n");
+    writeText(path.join(dir, "app.js"), "console.log('ok');\n");
+    writeText(path.join(dir, "payload.bin"), "not allowed");
+    writeJson(path.join(dir, "vibefi.json"), {
+      addresses: {
+        "31337": {
+          dappRegistry: "0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2"
+        }
+      }
+    });
+
+    await expect(
+      packageDapp({
+        path: dir,
+        name: "Static",
+        version: "0.0.1",
+        description: "test",
+        ipfs: false
+      })
+    ).rejects.toThrow(/Static-html layout does not allow file type/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add strict extension allowlist for `static-html` packaging
- allow only `.html`, `.js`, `.json` (no arbitrary files)
- reject all other file extensions with a clear error
- keep constrained layout validation unchanged
- update README/SPEC to match the stricter static-html policy

## Validation
- `bun run typecheck`
- `bun run test:unit`
- runtime negative check: `.bin` file is rejected
- zFi static-html packaging still succeeds
